### PR TITLE
inmemory token storage のテスト

### DIFF
--- a/app/authz/token/storage/inmemory_test.go
+++ b/app/authz/token/storage/inmemory_test.go
@@ -51,3 +51,19 @@ func TestInMemoryStorage_GetTokenData(t *testing.T) {
 		}
 	}
 }
+
+func TestInMemoryStorage_DeleteToken(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	err := storage.SetTokenData("key", "abc")
+	if err != nil {
+		t.Fatalf("err should be nil: got %v", err)
+	}
+}
+
+func TestInMemoryStorage_SetTokenData(t *testing.T) {
+	storage := NewInMemoryTokenStorage()
+	err := storage.DeleteToken("key")
+	if err != nil {
+		t.Fatalf("err should be nil: got %v", err)
+	}
+}

--- a/app/authz/token/storage/inmemory_test.go
+++ b/app/authz/token/storage/inmemory_test.go
@@ -20,3 +20,34 @@ func TestSetTokenDataConccurency(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestInMemoryStorage_GetTokenData(t *testing.T) {
+	tests := []struct {
+		key       string
+		value     string
+		searchKey string
+		want      string
+		wantError bool
+	}{
+		{"key", "abc", "k", "", true},
+		{"key", "abc", "key", "abc", false},
+	}
+
+	for _, tt := range tests {
+		storage := NewInMemoryTokenStorage()
+		_ = storage.SetTokenData(tt.key, tt.value)
+		got, err := storage.GetTokenData(tt.searchKey)
+
+		if !tt.wantError && err != nil {
+			t.Fatalf("want no err, but has error %v", err)
+		}
+
+		if tt.wantError && err == nil {
+			t.Fatalf("want err, but has no err")
+		}
+
+		if tt.want != got {
+			t.Fatalf("token data mismatch. want: %s, got: %s", tt.want, got)
+		}
+	}
+}

--- a/app/authz/token/storage/inmemory_test.go
+++ b/app/authz/token/storage/inmemory_test.go
@@ -23,19 +23,19 @@ func TestSetTokenDataConccurency(t *testing.T) {
 
 func TestInMemoryStorage_GetTokenData(t *testing.T) {
 	tests := []struct {
-		key       string
-		value     string
+		token     string
+		data      string
 		searchKey string
 		want      string
 		wantError bool
 	}{
-		{"key", "abc", "k", "", true},
-		{"key", "abc", "key", "abc", false},
+		{"token", "abc", "tockn", "", true},
+		{"token", "abc", "token", "abc", false},
 	}
 
 	for _, tt := range tests {
 		storage := NewInMemoryTokenStorage()
-		_ = storage.SetTokenData(tt.key, tt.value)
+		_ = storage.SetTokenData(tt.token, tt.data)
 		got, err := storage.GetTokenData(tt.searchKey)
 
 		if !tt.wantError && err != nil {
@@ -52,17 +52,17 @@ func TestInMemoryStorage_GetTokenData(t *testing.T) {
 	}
 }
 
-func TestInMemoryStorage_DeleteToken(t *testing.T) {
+func TestInMemoryStorage_SetTokenData(t *testing.T) {
 	storage := NewInMemoryTokenStorage()
-	err := storage.SetTokenData("key", "abc")
+	err := storage.DeleteToken("token")
 	if err != nil {
 		t.Fatalf("err should be nil: got %v", err)
 	}
 }
 
-func TestInMemoryStorage_SetTokenData(t *testing.T) {
+func TestInMemoryStorage_DeleteToken(t *testing.T) {
 	storage := NewInMemoryTokenStorage()
-	err := storage.DeleteToken("key")
+	err := storage.SetTokenData("token", "abc")
 	if err != nil {
 		t.Fatalf("err should be nil: got %v", err)
 	}


### PR DESCRIPTION
Fix #80 

`app/authz/token/storage/inmemory_test.go`
のカバレッジが
100.00% <0.00%> (+61.53%)
になった🥺

codecovの使い方だいたい分かったので、続いてテスト書いていきます。