### PR TITLE
ピンを保存するAPIを生やした

### DIFF
--- a/app/db/datastorage.go
+++ b/app/db/datastorage.go
@@ -57,14 +57,16 @@ func NewDataStorage(db *sql.DB, s3 S3) DataStorageInterface {
 func NewRepositoryMock() DataStorageInterface {
 	users := mocks.NewUserRepository()
 	boards := mocks.NewBoardRepository()
+	boardPins := mocks.NewBoardPinRepository()
 	pins := mocks.NewPinRepository()
 	tags := mocks.NewTagRepository()
 	awsS3 := mocks.NewAWSS3Repository()
 	return &DataStorage{
-		users:  users,
-		boards: boards,
-		pins:   pins,
-		tags:   tags,
-		awss3:  awsS3,
+		users:      users,
+		boards:     boards,
+		boardsPins: boardPins,
+		pins:       pins,
+		tags:       tags,
+		awss3:      awsS3,
 	}
 }

--- a/app/mocks/board_pins.go
+++ b/app/mocks/board_pins.go
@@ -1,0 +1,14 @@
+package mocks
+
+import "app/repository"
+
+type BoardPinMock struct {
+}
+
+func NewBoardPinRepository() repository.BoardPinRepository {
+	return &BoardPinMock{}
+}
+
+func (b BoardPinMock) CreateBoardPin(boardID int, pinID int) error {
+	return nil
+}

--- a/app/mocks/board_pins_test.go
+++ b/app/mocks/board_pins_test.go
@@ -1,0 +1,50 @@
+package mocks
+
+import (
+	"app/repository"
+	"reflect"
+	"testing"
+)
+
+func TestBoardPinMock_CreateBoardPin(t *testing.T) {
+	tests := []struct {
+		name    string
+		boardID int
+		pinID   int
+		wantErr bool
+	}{
+		{
+			name:    "create board pin",
+			boardID: 0,
+			pinID:   0,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := BoardPinMock{}
+			if err := b.CreateBoardPin(tt.boardID, tt.pinID); (err != nil) != tt.wantErr {
+				t.Errorf("CreateBoardPin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewBoardPinRepository(t *testing.T) {
+	tests := []struct {
+		name string
+		want repository.BoardPinRepository
+	}{
+		{
+			name: "new board pin repository",
+			want: &BoardPinMock{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewBoardPinRepository(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewBoardPinRepository() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/app/server/handlers/board.go
+++ b/app/server/handlers/board.go
@@ -133,3 +133,40 @@ func UpdateBoard(data db.DataStorageInterface, authLayer authz.AuthLayerInterfac
 		}
 	}
 }
+
+func SavePin(data db.DataStorageInterface, authLayer authz.AuthLayerInterface) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+
+		vars := mux.Vars(r)
+		boardID, err := strconv.Atoi(vars["boardID"])
+		if err != nil {
+			logs.Error("Request: %s, an error occurred: %v", requestSummary(r), err)
+			err := helpers.NewBadRequest(err)
+			ResponseError(w, r, err)
+			return
+		}
+
+		pinID, err := strconv.Atoi(vars["pinID"])
+		if err != nil {
+			logs.Error("Request: %s, an error occurred: %v", requestSummary(r), err)
+			err := helpers.NewBadRequest(err)
+			ResponseError(w, r, err)
+			return
+		}
+
+		err = usecase.SavePin(data, boardID, pinID)
+		if err != nil {
+			logs.Error("Request: %s, failed to save pin: %v", requestSummary(r), err)
+			err := helpers.NewInternalServerError(err)
+			ResponseError(w, r, err)
+			return
+		}
+
+		w.Header().Set(contentType, jsonContent)
+		w.WriteHeader(http.StatusCreated)
+		if _, err = w.Write([]byte("{}")); err != nil {
+			logs.Error("Request: %s, writing response: %v", requestSummary(r), err)
+		}
+	}
+}

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -55,6 +55,7 @@ func attachReqAuth(mux *mux.Router, data db.DataStorageInterface, al authz.AuthL
 
 	mux.HandleFunc("/boards", handlers.CreateBoard(data, al)).Methods(http.MethodPost)
 	mux.HandleFunc("/boards/{id}/pins", handlers.CreatePin(data, al, lambda)).Methods(http.MethodPost)
+	mux.HandleFunc("/boards/{boardID}/pins/{pinID}", handlers.SavePin(data, al)).Methods(http.MethodPost)
 	mux.HandleFunc("/boards/{id}", handlers.UpdateBoard(data, al)).Methods(http.MethodPut)
 	mux.HandleFunc("/pins/{id}", handlers.UpdatePin(data, al)).Methods(http.MethodPut)
 	mux.HandleFunc("/users/{id}", handlers.UpdateUser(data, al)).Methods(http.MethodPut)

--- a/app/usecase/board.go
+++ b/app/usecase/board.go
@@ -55,5 +55,8 @@ func SavePin(data db.DataStorageInterface, boardID int, pinID int) error {
 		return err
 	}
 
+	// TODO: Check if board-pin row already exists
+	// See: https://github.com/team-e-org/backend/issues/242
+
 	return data.BoardsPins().CreateBoardPin(boardID, pinID)
 }

--- a/app/usecase/board.go
+++ b/app/usecase/board.go
@@ -40,3 +40,20 @@ func UpdateBoard(data db.DataStorageInterface, board *models.Board) (*models.Boa
 
 	return board, nil
 }
+
+func SavePin(data db.DataStorageInterface, boardID int, pinID int) error {
+	// Check board and pin exist
+	_, err := data.Boards().GetBoard(boardID)
+	if err != nil {
+		logs.Error("An error occurred while checking board exists: %v", err)
+		return err
+	}
+
+	_, err = data.Pins().GetPin(pinID)
+	if err != nil {
+		logs.Error("An error occurred while checking pin exists: %v", err)
+		return err
+	}
+
+	return data.BoardsPins().CreateBoardPin(boardID, pinID)
+}

--- a/app/usecase/board_test.go
+++ b/app/usecase/board_test.go
@@ -5,6 +5,7 @@ import (
 	"app/models"
 	"app/ptr"
 	"testing"
+	"time"
 )
 
 func TestCreateBoard(t *testing.T) {
@@ -54,5 +55,80 @@ func TestUpdateBoard(t *testing.T) {
 	_, err = UpdateBoard(data, boardUpdated)
 	if err != nil {
 		t.Fatalf("An error occurred: %v", err)
+	}
+}
+
+func TestSavePin(t *testing.T) {
+	data := db.NewRepositoryMock()
+	userID := 1
+	boardID := 2
+	pinID := 3
+	board := &models.Board{
+		ID:          boardID,
+		UserID:      userID,
+		Name:        "test board",
+		Description: ptr.NewString("test description"),
+		IsPrivate:   false,
+		IsArchive:   false,
+	}
+
+	_, err := CreateBoard(data, board)
+	if err != nil {
+		t.Fatalf("An error occ")
+	}
+
+	pin := &models.Pin{
+		ID:          pinID,
+		UserID:      ptr.NewInt(userID),
+		Title:       "test title",
+		Description: ptr.NewString("test description"),
+		URL:         ptr.NewString("test url"),
+		ImageURL:    "test image url",
+		IsPrivate:   false,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	_, err = CreatePin(data, pin, boardID)
+	if err != nil {
+		t.Fatalf("An error occ")
+	}
+
+	tests := []struct {
+		name    string
+		data    db.DataStorageInterface
+		boardID int
+		pinID   int
+		wantErr bool
+	}{
+		{
+			name:    "save pin",
+			data:    data,
+			boardID: 2,
+			pinID:   3,
+			wantErr: false,
+		},
+		{
+			name:    "board doesn't exist",
+			data:    data,
+			boardID: 99,
+			pinID:   3,
+			wantErr: true,
+		},
+		{
+			name:    "pin doesn't exist",
+			data:    data,
+			boardID: 2,
+			pinID:   99,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := SavePin(tt.data, tt.boardID, tt.pinID); (err != nil) != tt.wantErr {
+				t.Errorf("SavePin() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/reference/openapi.yaml
+++ b/reference/openapi.yaml
@@ -339,6 +339,32 @@ paths:
                   type: boolean
       security:
         - X-Auth-Token: []
+  '/boards/{boardID}/pins/{pinID}':
+    parameters:
+      - schema:
+          type: string
+        name: boardID
+        in: path
+        required: true
+      - schema:
+          type: string
+        name: pinID
+        in: path
+        required: true
+    post:
+      summary: ''
+      operationId: post-boards-boardID-pins-pinID
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: {}
+      parameters: []
+      security:
+        - X-Auth-Token: []
   /users/sign-up:
     post:
       summary: ''


### PR DESCRIPTION
やったこと

* ピンを保存するAPIを生やした
* BoardPinRepositoryのmockがなかったので作った
* swaggerを更新

--

懸念点

* キー制約がないので、boardpinテーブルに同じ内容のデータを突っ込めてしまう。言い換えれば、何回でも同じピンを同じボードに追加できる。クライアントで保存ボタンを連打できないようにするとともに、/board/{id}/pins でIDが重複しているPinを除く処理が必要と思った。
