### PR TITLE
CloudFrontからのみS3の画像にアクセスできるようにした

### DIFF
--- a/app/infrastructure/aws_s3.go
+++ b/app/infrastructure/aws_s3.go
@@ -22,7 +22,8 @@ type AWSS3 struct {
 func NewAWSS3(c config.S3) repository.FileRepository {
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
 		Config: aws.Config{
-			Region: aws.String(c.Region),
+			Region:                        aws.String(c.Region),
+			CredentialsChainVerboseErrors: aws.Bool(true),
 		},
 	}))
 

--- a/app/infrastructure/aws_s3.go
+++ b/app/infrastructure/aws_s3.go
@@ -66,7 +66,7 @@ func (a *AWSS3) UploadImage(file multipart.File, fileHeader *multipart.FileHeade
 	}
 
 	result, err := a.Uploader.Upload(&s3manager.UploadInput{
-		ACL:         aws.String("public-read"),
+		ACL:         aws.String("private"),
 		Body:        file,
 		Bucket:      aws.String(a.Config.Bucket),
 		ContentType: aws.String(contentType),


### PR DESCRIPTION
やったこと

* ACLを `public-read` から `private` に
* ついでに自分の環境でaws keyが上手く設定されていなくハマったので、credential関係のエラーを表示するオプションをオンにした

参考: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#CannedACL